### PR TITLE
[PKG-2517] parsedatetime 2.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,24 @@
 {% set name = "parsedatetime" %}
 {% set version = "2.6" %}
-{% set bundle = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash = "4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455" %}
-{% set build = 0 %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{ hash }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455
 
 build:
-  number: {{ build }}
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
+    - pip
     - setuptools
-    - pytest-runner
-
+    - wheel
   run:
     - python
 
@@ -31,13 +26,19 @@ test:
   imports:
     - parsedatetime
     - parsedatetime.pdt_locales
+  requires: 
+    - pip
+  commands: 
+    - pip check
 
 about:
   home: https://github.com/bear/parsedatetime
   license_file: LICENSE.txt
-  license: Apache 2.0
+  license: Apache-2.0
   license_family: Apache
-  summary: 'Parse human-readable date/time text.'
+  summary: Parse human-readable date/time text
+  description: |
+    Parse human-readable date/time strings.
   dev_url: https://github.com/bear/parsedatetime
   doc_url: https://bear.im/code/parsedatetime/docs/index.html
 


### PR DESCRIPTION
Changelog: https://github.com/bear/parsedatetime/releases
License: https://github.com/bear/parsedatetime/blob/v2.6/LICENSE.txt
Requirements: https://github.com/bear/parsedatetime/blob/v2.6/setup.py

Actions:
1. Clean up the recipe:
- Remove unused jinja2 variables
- Remove `noarch` python
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `wheel` to `host`
- Add pip check
2. Remove `pytest-runner` from `host` and add `pip`
3. Fix the `license` name
4. Add a `description`

Notes:
- `agate` relies on `parsedatetime` but v2.4 had `future` as a dependency but our recipe hasn't it so pip check raises an error. But `future` package is not maintained anymore for years